### PR TITLE
Group fields and methods in encoder #19

### DIFF
--- a/src/main/scala/org/uqbar/thin/encoding/combinator/Encoders.scala
+++ b/src/main/scala/org/uqbar/thin/encoding/combinator/Encoders.scala
@@ -124,7 +124,7 @@ case class On[T](target: Encoder[T]) extends Location[T]
 case class InBetween[T](target: Encoder[List[T]]) extends Location[(T,T,List[T])]
 
 protected case class LocationKey[+T](val location: Location[T], val target: T)
-  
+
 protected case class LocationRule[+T](location: Location[T])(condition: Option[PartialFunction[Any,Boolean]]) {
 	def matches[U>:T](key: LocationKey[U]) = {
 		key.location == location && condition.forall{ condition => condition.applyOrElse(key.target, {_: Any => false})

--- a/src/main/scala/org/uqbar/thin/encoding/combinator/package.scala
+++ b/src/main/scala/org/uqbar/thin/encoding/combinator/package.scala
@@ -5,5 +5,5 @@ import scala.language.implicitConversions
 package object combinator {
 
 	implicit def StringToEncoderResult(s: String) = EncoderResult(s)
-
+	
 }

--- a/src/main/scala/org/uqbar/thin/encoding/combinator/package.scala
+++ b/src/main/scala/org/uqbar/thin/encoding/combinator/package.scala
@@ -5,4 +5,5 @@ import scala.language.implicitConversions
 package object combinator {
 
 	implicit def StringToEncoderResult(s: String) = EncoderResult(s)
+
 }

--- a/src/main/scala/org/uqbar/thin/javaless/JavalessEncoder.scala
+++ b/src/main/scala/org/uqbar/thin/javaless/JavalessEncoder.scala
@@ -10,10 +10,7 @@ import org.uqbar.thin.encoding.combinator.Encoders
 import org.uqbar.thin.encoding.combinator.InBetween
 import org.uqbar.thin.encoding.combinator.Location
 import org.uqbar.thin.encoding.combinator.On
-import org.uqbar.thin.encoding.combinator.SimpleLocationRule
-import org.uqbar.thin.encoding.combinator.InfixLocationRule
 import org.uqbar.thin.encoding.combinator.LocationRule
-import org.uqbar.thin.encoding.combinator.SimpleLocationRule
 
 class JavalessEncoder(_terminals: => Map[Symbol, String] = DefaultTerminals, _preferences: => EncoderPreferences = null) extends JavalessEncoderDefinition {
 	def terminals = _terminals
@@ -45,10 +42,9 @@ trait JavalessEncoderDefinition extends Encoders {
 		tabulationSequence = "\t",
 
 		tabulationSize = 1,
-
 		lineBreaks = Map(
-			Before(classMember.*){_.nonEmpty } -> 1,
-			After(classMember.*){ _.nonEmpty } -> 1,
+			Before(classMember.*){case _::_ => true} -> 1,
+			After(classMember.*){case _::_ => true } -> 1,
 			InBetween(classMember.*){case (_,r: Method,_) => true} -> 2
 		),
 

--- a/src/main/scala/org/uqbar/thin/javaless/JavalessEncoder.scala
+++ b/src/main/scala/org/uqbar/thin/javaless/JavalessEncoder.scala
@@ -13,6 +13,7 @@ import org.uqbar.thin.encoding.combinator.On
 import org.uqbar.thin.encoding.combinator.SimpleLocationRule
 import org.uqbar.thin.encoding.combinator.InfixLocationRule
 import org.uqbar.thin.encoding.combinator.LocationRule
+import org.uqbar.thin.encoding.combinator.SimpleLocationRule
 
 class JavalessEncoder(_terminals: => Map[Symbol, String] = DefaultTerminals, _preferences: => EncoderPreferences = null) extends JavalessEncoderDefinition {
 	def terminals = _terminals
@@ -35,10 +36,10 @@ trait JavalessEncoderDefinition extends Encoders {
 
 	lazy val DefaultPreferences = new EncoderPreferences(
 		spacing = Set(
-			SimpleLocationRule(After('class))(),
-			SimpleLocationRule(After('argumentSeparator))(),
-			SimpleLocationRule(Before('contextOpen))(),
-			InfixLocationRule(InBetween(classMember.*)){case (l: Field,r: Field,_) => true}
+			After('class)(),
+			After('argumentSeparator)(),
+			Before('contextOpen)(),
+			InBetween(classMember.*){case (l: Field,r: Field,_) => true}
 		),
 
 		tabulationSequence = "\t",
@@ -46,13 +47,13 @@ trait JavalessEncoderDefinition extends Encoders {
 		tabulationSize = 1,
 
 		lineBreaks = Map(
-			SimpleLocationRule(Before(classMember.*)){ case l: List[_] => l.nonEmpty } -> 1,
-			SimpleLocationRule(After(classMember.*)){ case l: List[_] => l.nonEmpty } -> 1,
-			InfixLocationRule(InBetween(classMember.*)){case (_,r: Method,_) => true} -> 2
+			Before(classMember.*){_.nonEmpty } -> 1,
+			After(classMember.*){ _.nonEmpty } -> 1,
+			InBetween(classMember.*){case (_,r: Method,_) => true} -> 2
 		),
 
 		tabulationLevelIncrements = Map(
-			SimpleLocationRule(On(classMember.*))() -> 1
+			On(classMember.*)() -> 1
 		)
 	)
 }

--- a/src/test/scala/org/uqbar/thin/javaless/JavalessEncoderTest.scala
+++ b/src/test/scala/org/uqbar/thin/javaless/JavalessEncoderTest.scala
@@ -71,11 +71,7 @@ class JavalessEncoderTest extends FreeSpec with JavalessEncoderDefinition with E
 
 					nonEmptyClass should beEncodedTo"""
 						${0}class ${1}MyClass${2} {
-							${3}foo${4}
-
-							${5}bar${6}
-
-							${7}meh${8}
+							${3}foo${4}	${5}bar${6}	${7}meh${8}
 						}${9}
 					"""(nonEmptyClass -> 0.until(9), nonEmptyClass.name -> 1.until(2), nonEmptyClass.body -> 3.until(8), field1 -> 3.until(4), field1.name -> 3.until(4), field2 -> 5.until(6), field2.name -> 5.until(6), field3 -> 7.until(8), field3.name -> 7.until(8))
 				}
@@ -90,11 +86,7 @@ class JavalessEncoderTest extends FreeSpec with JavalessEncoderDefinition with E
 
 					nonEmptyClass should beEncodedTo"""
 						${0}class ${1}MyClass${2} {
-							${3}foo${4}
-
-							${5}bar${6}
-
-							${7}meh${8}
+							${3}foo${4}	${5}bar${6}	${7}meh${8}
 
 							${9}calculate${10}(${11}) {}${12}
 


### PR DESCRIPTION
Added advanced location config, based on the context of the encoded element.

This makes possible to apply a different spacing/tab/br to elements in the same collection (like class members), and opens the door for further crazier customization.

Closes #19 